### PR TITLE
修复输入年份时的异常处理漏洞

### DIFF
--- a/Self-writtenCode/LibraryManager/LibraryManager.java
+++ b/Self-writtenCode/LibraryManager/LibraryManager.java
@@ -140,8 +140,21 @@ public class LibraryManager {
         System.out.print("请输入 ISBN 编号：");
         String isbn = scanner.nextLine();
         System.out.print("请输入出版年份：");
-        int year = Integer.parseInt(scanner.nextLine());
+        
+        int year = -1;
+        while (year < 0) {
+            try {
+                System.out.print("请输入出版年份：");
+                year = Integer.parseInt(scanner.nextLine());
+                if (year < 0) {
+                    System.out.println("⚠️ 出版年份必须为非负整数！");
+                }   
+            } catch (NumberFormatException e) {
+                System.out.println("⚠️ 输入错误，请输入数字！");
+            }
+        }
 
+        
         Book book = new Book(title, author, isbn, year);
         library.addBook(book);
     }


### PR DESCRIPTION
问题描述：
在 addBookProcess 方法中，用户输入出版年份时直接使用 Integer.parseInt 转换输入，未处理非数字输入。当用户输入非数字字符时，程序会抛出 NumberFormatException 并终止，用户体验较差。
